### PR TITLE
Move the color dialog to document root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components

--- a/l2t-paper-color.html
+++ b/l2t-paper-color.html
@@ -137,6 +137,7 @@ Custom property | Description | Default
       _dialogHandler(e) {
         if(e.detail) {
           this.value = this.colorDialog.color;
+          this.dispatchEvent(new CustomEvent('change'));
         }
       }
       /**

--- a/l2t-paper-color.html
+++ b/l2t-paper-color.html
@@ -49,10 +49,6 @@ Custom property | Description | Default
       <iron-icon icon="label" slot="prefix"></iron-icon>
       <iron-icon icon="image:palette" slot="suffix"></iron-icon>
     </paper-input>
-    <l2t-paper-color-dialog
-      colors="{{colors}}"
-      hide-advanced$="[[hideAdvanced]]">
-    </l2t-paper-color-dialog>
 
   </template>
 
@@ -140,7 +136,7 @@ Custom property | Description | Default
       */
       _dialogHandler(e) {
         if(e.detail) {
-          this.value = this.shadowRoot.querySelector('l2t-paper-color-dialog').color;
+          this.value = this.colorDialog.color;
         }
       }
       /**
@@ -150,13 +146,19 @@ Custom property | Description | Default
         if(this.readonly)
           return
 
-        var colorDialog = this.shadowRoot.querySelector('l2t-paper-color-dialog');
-        colorDialog.color=this.value||colorDialog.color;
-        colorDialog.open();
+        this.colorDialog.color = this.value||this.colorDialog.color;
+        this.colorDialog.open();
+      }
+      _createDialog() {
+        this.colorDialog = document.createElement('l2t-paper-color-dialog');
+        this.colorDialog.colors = this.colors;
+        this.colorDialog.hideAdvanced = this.hideAdvanced;
+        document.body.appendChild(this.colorDialog);
       }
       ready(){
         super.ready();
-        this.addEventListener("paper-color-dialog-closed", function(e){this._dialogHandler(e)}, false);
+        this._createDialog();
+        this.colorDialog.addEventListener("paper-color-dialog-closed", (e) => this._dialogHandler(e), false);
       }
     }
 

--- a/polymer.json
+++ b/polymer.json
@@ -1,0 +1,7 @@
+{
+  "lint": {
+    "rules": [
+      "polymer-2"
+    ]
+  }
+}


### PR DESCRIPTION
Currently when the element it's inside a fixed element, the dialog stay behind the overlay.
An example here https://github.com/PolymerElements/paper-dialog/issues/7

